### PR TITLE
Added options that enhance file location customizability

### DIFF
--- a/src/services/cloudinary.js
+++ b/src/services/cloudinary.js
@@ -4,54 +4,78 @@ import { v2 as cloudinary } from "cloudinary";
 import { FileService } from "medusa-interfaces";
 
 class CloudinaryService extends FileService {
-	constructor({}, options) {
-		super();
+  constructor({}, options) {
+    super();
 
-        cloudinary.config({
-            cloud_name: options.cloud_name,
-			api_key: options.api_key,
-			api_secret: options.api_secret,
-			secure: options.secure || true,
-        });
-	}
+    this.root_ = options.root_folder;
+    this.nameToPath_ = options.use_file_name_as_path || false;
+    this.nonPublicIdSlashCount_ = 7;
 
-	// File upload
-	upload(file) {
-		return new Promise((resolve, reject) => {
-			var upload_stream = cloudinary.uploader.upload_stream(
-				{},
-				function (err, image) {
-					if (err) {
-						console.error(err);
-						reject(err);
-						return;
-					}
-					resolve({ url: image.url });
-				}
-			);
-			fs.createReadStream(file.path).pipe(upload_stream);
-		});
-	}
+    cloudinary.config({
+      cloud_name: options.cloud_name,
+      api_key: options.api_key,
+      api_secret: options.api_secret,
+      secure: options.secure || true,
+    });
+  }
 
-	delete(file) {
-		// file is the url of image. We have to extract the public id from url
-		let publicId;
-		if (
-			typeof file === "string" &&
-			file.toLowerCase().includes("cloudinary")
-		) {
-			// Remove the last '/' before public id and '.' before file extension
-			publicId = file.substring(
-				file.lastIndexOf("/") + 1,
-				file.lastIndexOf(".")
-			);
-		} else {
-			publicId = file;
-		}
-		cloudinary.uploader.destroy(publicId, function (result) {
-			resolve(result);
-		});
-	}
+  // File upload
+  upload(file) {
+    const publicId = this.buildPublicId(file.originalname);
+
+    return new Promise((resolve, reject) => {
+      const upload_stream = cloudinary.uploader.upload_stream(
+        { folder: this.root_, public_id: publicId },
+        (err, image) => {
+          if (err) {
+            console.error(err);
+            reject(err);
+            return;
+          }
+          console.log(image);
+          resolve({ url: image.url });
+        }
+      );
+      fs.createReadStream(file.path).pipe(upload_stream);
+    });
+  }
+
+  delete(file) {
+    // file is the url of image. We have to extract the public id from url
+    let publicId;
+    if (typeof file === "string" && file.toLowerCase().includes("cloudinary")) {
+      publicId = this.extractPublicId(file);
+    } else {
+      publicId = file;
+    }
+    cloudinary.uploader.destroy(publicId, function (result) {
+      resolve(result);
+    });
+  }
+
+  /* ------------------------------ helper methods ------------------------------ */
+
+  buildPublicId(originalFileName) {
+    const fileName = this.removeExtension(originalFileName);
+    const cleanFileName = fileName.replace(/\s+/g, "-"); // convert ' ' to '-'
+
+    const filePath = this.nameToPath_
+      ? cleanFileName.split(".").join("/")
+      : cleanFileName;
+
+    const uniqueSuffix = Date.now();
+    return `${filePath}_${uniqueSuffix}`;
+  }
+
+  extractPublicId(url) {
+    // example: https://res.cloudinary.com/<cloud_name>/image/upload/v1676396191/store/file-name_1676396190050.png
+    const cUrl = this.removeExtension(url);
+    return cUrl.split("/").slice(this.nonPublicIdSlashCount_).join("/");
+  }
+
+  removeExtension(name) {
+    return name.split(".").slice(0, -1).join(".");
+  }
 }
 
 export default CloudinaryService;


### PR DESCRIPTION
### Issues I had while using this plugin:
1. Images where stored in the home directory of my cloudinary account
2. Public Ids were random strings that cloudinary generated

### Issue No.1 Solution
I added two options to the plugin config:
1. root_folder (string)
2. use_file_name_as_path (boolean)

#### 'root_folder' option
- This option allows the plugin users to specify a certain folder under their cloudinary 'Home' folder to store all their images under
- It can be a name of a folder like 'online_store' or a path like 'online_store/assets/images' (cannot start or end with a '/')
- If root_folder value was '' (empty string), undefined or null, this will have no effect and images will be stored in 'Home' folder

#### 'use_file_name_as_path ' option
- If set to true, this option allows the plugin user to store their image in a subdirectory of their root folder if their file name includes dots (.) excluding the extension dot.
- For example: if the file name was "products.shoes.png" the path of the file under would be "Home/root_folder/products/shoes"

### Issue No.2 Solution
I used cloudinary public_id upload option in order to specify a unique name using file name and date instead of a random name

### backward compatibility
If these options were left untouched this change it won't have any effect