### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
     api_key: [cloudinary api key],
     api_secret: [cloudinary api secret],
     secure: [enable secure uploads, default true],
-    root_folder: [folder to which images should be uploaded[
+    root_folder: [folder to which images should be uploaded]
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
     api_key: [cloudinary api key],
     api_secret: [cloudinary api secret],
     secure: [enable secure uploads, default true],
+    root_folder: [folder to which images should be uploaded[
 ```
 
 ## Usage
@@ -31,6 +32,7 @@ Then configure your `medusa-config.js` to include the plugin alongside the requi
         cloud_name: "YOUR_CLOUD_NAME",
         api_key: "YOUR_API_KEY",
         api_secret: "YOUR_API_SECRET",
+        root_folder: "ProductMedia",
         secure: true,
     },
 },

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Then configure your `medusa-config.js` to include the plugin alongside the requi
         cloud_name: "YOUR_CLOUD_NAME",
         api_key: "YOUR_API_KEY",
         api_secret: "YOUR_API_SECRET",
-        root_folder: "ProductMedia",
+        root_folder: "YOUR_FOLDER_NAME",
         secure: true,
     },
 },


### PR DESCRIPTION
# why to do this?
### because without root_doler name plugin  is not working, that's why it is necessary to inform new users about this

Fixes #3 